### PR TITLE
Add swipe-based expense categorization tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# codexTesting
+# Swipe Expenses Tool
+
+This repo contains a simple tool to help categorize bank transactions using a swipe-like interface.
+
+## Requirements
+- Python 3.12+
+- A web browser
+
+## Usage
+1. Export your transactions from HSBC, Wells Fargo or Citibank as a CSV file with columns including `Date`, `Description`, and `Amount`.
+2. Convert the CSV to a JSON file using the parser:
+   ```bash
+   python3 swipe_expenses/parse_transactions.py yourfile.csv -b HSBC -o swipe_expenses/transactions.json
+   ```
+3. Open `swipe_expenses/index.html` in a browser. Use the buttons or arrow keys to categorize each transaction. Results are displayed at the end of the session.
+
+A sample `transactions.json` is provided for demonstration.

--- a/swipe_expenses/index.html
+++ b/swipe_expenses/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Swipe Expenses</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>Swipe Expenses</h1>
+<div id="card-container">
+  <div id="transaction-card" class="card hidden">
+    <p id="t-date"></p>
+    <p id="t-desc"></p>
+    <p id="t-amount"></p>
+  </div>
+</div>
+<div id="buttons" class="hidden">
+  <button data-cat="Food">Food</button>
+  <button data-cat="Education">Education</button>
+  <button data-cat="Entertainment">Entertainment</button>
+  <button data-cat="Other">Other</button>
+</div>
+<pre id="result"></pre>
+<script src="main.js"></script>
+</body>
+</html>

--- a/swipe_expenses/main.js
+++ b/swipe_expenses/main.js
@@ -1,0 +1,45 @@
+let transactions = [];
+let index = 0;
+const results = [];
+
+fetch('transactions.json')
+  .then(r => r.json())
+  .then(data => {
+    transactions = data;
+    showNext();
+  });
+
+function showNext() {
+  const card = document.getElementById('transaction-card');
+  const btns = document.getElementById('buttons');
+  if (index >= transactions.length) {
+    card.classList.add('hidden');
+    btns.classList.add('hidden');
+    document.getElementById('result').textContent = JSON.stringify(results, null, 2);
+    return;
+  }
+  const t = transactions[index];
+  document.getElementById('t-date').textContent = t.date;
+  document.getElementById('t-desc').textContent = t.description;
+  document.getElementById('t-amount').textContent = '$' + t.amount;
+  card.classList.remove('hidden');
+  btns.classList.remove('hidden');
+}
+
+function choose(cat) {
+  const t = transactions[index];
+  results.push({...t, category: cat});
+  index += 1;
+  showNext();
+}
+
+document.querySelectorAll('#buttons button').forEach(btn => {
+  btn.addEventListener('click', () => choose(btn.dataset.cat));
+});
+
+window.addEventListener('keydown', (e) => {
+  if (e.key === 'ArrowLeft') choose('Food');
+  if (e.key === 'ArrowRight') choose('Education');
+  if (e.key === 'ArrowUp') choose('Entertainment');
+  if (e.key === 'ArrowDown') choose('Other');
+});

--- a/swipe_expenses/parse_transactions.py
+++ b/swipe_expenses/parse_transactions.py
@@ -1,0 +1,44 @@
+import csv
+import json
+import argparse
+from datetime import datetime
+
+
+def parse_csv(file_path, bank=None):
+    # Basic parser that expects header fields: Date, Description, Amount
+    transactions = []
+    with open(file_path, newline='', encoding='utf-8-sig') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            date = row.get('Date') or row.get('Transaction Date') or row.get('Posting Date')
+            description = row.get('Description') or row.get('Details')
+            amount = row.get('Amount') or row.get('Debit') or row.get('Credit')
+            try:
+                amount = float(amount.replace(',', '')) if amount else 0.0
+            except ValueError:
+                amount = 0.0
+            transactions.append({
+                'date': date,
+                'description': description,
+                'amount': amount,
+                'bank': bank,
+            })
+    return transactions
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Convert bank CSV to transactions JSON')
+    parser.add_argument('csv', help='CSV file exported from bank')
+    parser.add_argument('-b', '--bank', default='Unknown', help='Bank name')
+    parser.add_argument('-o', '--output', default='transactions.json', help='Output JSON file')
+    args = parser.parse_args()
+
+    data = parse_csv(args.csv, args.bank)
+    with open(args.output, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2)
+
+    print(f'Wrote {len(data)} transactions to {args.output}')
+
+
+if __name__ == '__main__':
+    main()

--- a/swipe_expenses/style.css
+++ b/swipe_expenses/style.css
@@ -1,0 +1,17 @@
+body {
+  font-family: Arial, sans-serif;
+  text-align: center;
+  margin: 20px;
+}
+.card {
+  border: 1px solid #ccc;
+  padding: 20px;
+  margin: 20px auto;
+  width: 300px;
+  box-shadow: 2px 2px 4px rgba(0,0,0,0.1);
+}
+.hidden { display: none; }
+#buttons button {
+  margin: 5px;
+  padding: 10px 20px;
+}

--- a/swipe_expenses/transactions.json
+++ b/swipe_expenses/transactions.json
@@ -1,0 +1,5 @@
+[
+  {"date": "2025-05-01", "description": "Textbook", "amount": 50.00, "bank": "Citibank"},
+  {"date": "2025-05-03", "description": "Groceries", "amount": 30.25, "bank": "HSBC"},
+  {"date": "2025-05-05", "description": "Movie", "amount": 12.00, "bank": "WellsFargo"}
+]


### PR DESCRIPTION
## Summary
- create a simple web UI to categorize transactions using a swipe-style workflow
- add a Python script to convert bank CSV exports to JSON
- include sample transactions and instructions in README

## Testing
- `python3 -m py_compile swipe_expenses/parse_transactions.py`
- `node --check swipe_expenses/main.js`


------
https://chatgpt.com/codex/tasks/task_e_683f718c13808323b3199600ef08e6b3